### PR TITLE
feat: add admin OCR review workflow

### DIFF
--- a/contractbot/notifications.py
+++ b/contractbot/notifications.py
@@ -1,8 +1,19 @@
 """Notification dataclasses."""
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class OcrResult:
+    """Represents OCR output for a specific named box."""
+
+    box_name: str
+    coordinates: Tuple[int, int, int, int]
+    recognized_text: str
+    image_path: Optional[str] = None
 
 
 @dataclass
@@ -13,3 +24,5 @@ class ContractNotification:
     est_total: float
     bisk_credited: float
     discord_user_id: Optional[int]
+    ocr_results: Sequence[OcrResult] = dataclasses.field(default_factory=tuple)
+    screenshot_path: Optional[str] = None


### PR DESCRIPTION
## Summary
- add slash commands for assigning an admin review channel and confirming/correcting OCR results while queueing training words
- persist OCR artifacts for each contract and include them in Discord admin notifications
- store OCR samples and incremental training data so the processor can update Tesseract user words automatically

## Testing
- python -m py_compile contractbot/notifications.py contractbot/ocr.py contractbot/processor.py contractbot/database.py contractbot/discord_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e19a8847a083209e23d01a1fcd817a